### PR TITLE
Add 'convert' command

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -55,7 +55,7 @@ def mypy(session: Session) -> None:
 def tests(session: Session) -> None:
     """Run the test suite."""
     session.install(".")
-    session.install("coverage[toml]", "pytest", "pygments", "pytest-datafiles")
+    session.install("coverage[toml]", "pytest", "pygments", "pytest-datafiles", "pytest-mock")
     try:
         session.run("coverage", "run", "--parallel", "-m", "pytest", *session.posargs)
     finally:
@@ -83,7 +83,7 @@ def coverage(session: Session) -> None:
 def typeguard(session: Session) -> None:
     """Runtime type checking using Typeguard."""
     session.install(".")
-    session.install("pytest", "typeguard", "pygments", "pytest-datafiles")
+    session.install("pytest", "typeguard", "pygments", "pytest-datafiles", "pytest-mock")
     session.run("pytest", f"--typeguard-packages={package}", *session.posargs)
 
 

--- a/src/playlist_along/cli.py
+++ b/src/playlist_along/cli.py
@@ -94,9 +94,4 @@ def convert(pls_obj: Playlist, dest: str, copy: bool) -> None:
 def convert_from_aimp_to_vlc_android(file: Path, dest: str, copy: bool) -> None:
     """Converts AIMP playlist to VLC for Android."""
     converted_pls, encoding = playlist.get_playlist_for_vlc_android(file)
-    target_pls: Path
-    if Path(dest).is_dir:
-        target_pls = Path(dest) / file.name
-    else:
-        target_pls = dest
-    target_pls.write_text(converted_pls, encoding)
+    playlist.save_playlist_content(converted_pls, Path(dest), encoding, file)

--- a/src/playlist_along/cli.py
+++ b/src/playlist_along/cli.py
@@ -86,24 +86,24 @@ def display(pls_obj: Playlist) -> None:
 )
 @click.option(
     "--dir",
-    "explicit_dir",
+    "yes_dir",
     is_flag=True,
     help="Tells script that destination is a dir, not a file (for directory name with '.' dot).",
 )
 @pass_playlist
-def convert(pls_obj: Playlist, dest: str, explicit_dir: bool, copy: bool) -> None:
+def convert(pls_obj: Playlist, dest: str, yes_dir: bool, copy: bool) -> None:
     """Converts playlist from one player to another."""
     file: Path = pls_obj.path
-    convert_from_aimp_to_vlc_android(file, dest, explicit_dir)
+    convert_from_aimp_to_vlc_android(file, dest, yes_dir)
     if copy:
         copy_files_from_playlist_to_destination_folder(file, dest)
 
 
-def convert_from_aimp_to_vlc_android(file: Path, dest: str, explicit_dir: bool) -> None:
+def convert_from_aimp_to_vlc_android(file: Path, dest: str, yes_dir: bool) -> None:
     """Converts AIMP playlist to VLC for Android."""
     converted_pls, encoding = playlist.get_playlist_for_vlc_android(file)
     playlist.save_playlist_content(
-        converted_pls, Path(dest), encoding, file, explicit_dir
+        converted_pls, Path(dest), encoding, file, yes_dir
     )
 
 

--- a/src/playlist_along/cli.py
+++ b/src/playlist_along/cli.py
@@ -84,19 +84,27 @@ def display(pls_obj: Playlist) -> None:
     is_flag=True,
     help="Copy files from playlist.",
 )
+@click.option(
+    "--dir",
+    "explicit_dir",
+    is_flag=True,
+    help="Tells script that destination is a dir, not a file (for directory name with '.' dot).",
+)
 @pass_playlist
-def convert(pls_obj: Playlist, dest: str, copy: bool) -> None:
+def convert(pls_obj: Playlist, dest: str, explicit_dir: bool, copy: bool) -> None:
     """Converts playlist from one player to another."""
     file: Path = pls_obj.path
-    convert_from_aimp_to_vlc_android(file, dest)
+    convert_from_aimp_to_vlc_android(file, dest, explicit_dir)
     if copy:
         copy_files_from_playlist_to_destination_folder(file, dest)
 
 
-def convert_from_aimp_to_vlc_android(file: Path, dest: str) -> None:
+def convert_from_aimp_to_vlc_android(file: Path, dest: str, explicit_dir: bool) -> None:
     """Converts AIMP playlist to VLC for Android."""
     converted_pls, encoding = playlist.get_playlist_for_vlc_android(file)
-    playlist.save_playlist_content(converted_pls, Path(dest), encoding, file)
+    playlist.save_playlist_content(
+        converted_pls, Path(dest), encoding, file, explicit_dir
+    )
 
 
 def copy_files_from_playlist_to_destination_folder(file: Path, dest: str) -> None:

--- a/src/playlist_along/cli.py
+++ b/src/playlist_along/cli.py
@@ -1,6 +1,6 @@
 """CLI commands and functions."""
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, List, Optional, Union
 
 import click
 from click import Context, Option, Parameter
@@ -88,10 +88,19 @@ def display(pls_obj: Playlist) -> None:
 def convert(pls_obj: Playlist, dest: str, copy: bool) -> None:
     """Converts playlist from one player to another."""
     file: Path = pls_obj.path
-    convert_from_aimp_to_vlc_android(file, dest, copy)
+    convert_from_aimp_to_vlc_android(file, dest)
+    if copy:
+        copy_files_from_playlist_to_destination_folder(file, dest)
 
 
-def convert_from_aimp_to_vlc_android(file: Path, dest: str, copy: bool) -> None:
+def convert_from_aimp_to_vlc_android(file: Path, dest: str) -> None:
     """Converts AIMP playlist to VLC for Android."""
     converted_pls, encoding = playlist.get_playlist_for_vlc_android(file)
     playlist.save_playlist_content(converted_pls, Path(dest), encoding, file)
+
+
+def copy_files_from_playlist_to_destination_folder(file: Path, dest: str) -> None:
+    """Copy tracks from playlist to folder with converted playlist."""
+    content, encoding = playlist.get_full_content_of_playlist(file)
+    only_tracks: List[str] = playlist.get_local_tracks_without_comment_lines(content)
+    playlist.copy_local_tracks_to_folder(only_tracks, dest)

--- a/src/playlist_along/cli.py
+++ b/src/playlist_along/cli.py
@@ -69,3 +69,34 @@ def display(pls_obj: Playlist) -> None:
     """Displays tracks from playlist."""
     file: Path = pls_obj.path
     echo_tracks_with_click(file)
+
+
+@cli.command()
+@click.option(
+    "--dest",
+    "-d",
+    type=str,
+    help="Directory or full path to playlist destination.",
+    metavar="<string>",
+)
+@click.option(
+    "--copy",
+    is_flag=True,
+    help="Copy files from playlist.",
+)
+@pass_playlist
+def convert(pls_obj: Playlist, dest: str, copy: bool) -> None:
+    """Converts playlist from one player to another."""
+    file: Path = pls_obj.path
+    convert_from_aimp_to_vlc_android(file, dest, copy)
+
+
+def convert_from_aimp_to_vlc_android(file: Path, dest: str, copy: bool) -> None:
+    """Converts AIMP playlist to VLC for Android."""
+    converted_pls, encoding = playlist.get_playlist_for_vlc_android(file)
+    target_pls: Path
+    if Path(dest).is_dir:
+        target_pls = Path(dest) / file.name
+    else:
+        target_pls = dest
+    target_pls.write_text(converted_pls, encoding)

--- a/src/playlist_along/playlist.py
+++ b/src/playlist_along/playlist.py
@@ -138,7 +138,11 @@ def copy_local_tracks_to_folder(tracklist: List[str], dest: str) -> None:
             name_only = Path(abs_path).name
             file_destination = destination / name_only
             if not file_destination.exists():
-                shutil.copy2(Path(abs_path), destination)
+                try:
+                    shutil.copy2(Path(abs_path), destination)
+                except (OSError) as error:
+                    message = str(error)
+                    raise ClickException(message)
     if missing_files:
         click.echo("Missing files from playlist were NOT copied:")
         click.echo("\n".join(missing_files))

--- a/src/playlist_along/playlist.py
+++ b/src/playlist_along/playlist.py
@@ -92,9 +92,10 @@ def save_playlist_content(
         target_pls = Path(dest) / origin.name
     else:
         target_pls = Path(dest)
-    if target_pls == origin:
-        suffix = target_pls.suffix
-        new_name = str(target_pls.resolve().with_suffix("")) + "_vlc" + suffix
-        target_pls = Path(new_name)
+    if origin:
+        if target_pls.resolve() == origin.resolve():
+            suffix = target_pls.suffix
+            new_name = str(target_pls.resolve().with_suffix("")) + "_vlc" + suffix
+            target_pls = Path(new_name)
 
     target_pls.write_text(content, encoding)

--- a/src/playlist_along/playlist.py
+++ b/src/playlist_along/playlist.py
@@ -1,8 +1,12 @@
 """Playlist module."""
 from pathlib import Path
-from typing import List, Optional
+import re
+from typing import List, Optional, Tuple
 
 from ._utils import _detect_file_encoding
+
+
+SONG_FORMATS: List[str] = [".mp3", ".flac"]
 
 
 class Playlist(object):
@@ -20,7 +24,47 @@ def get_only_track_paths_from_m3u(
     if encoding is None:
         encoding = _detect_file_encoding(path)
     playlist_content = path.read_text(encoding=encoding)
-    only_paths = [
-        line.strip() for line in playlist_content.splitlines() if line[0] != "#"
-    ]
+    only_paths = get_tracks_without_comment_lines(playlist_content)
     return only_paths
+
+
+def get_tracks_without_comment_lines(playlist_content: str) -> List[str]:
+    """Return list of tracks."""
+    only_tracks: List[str] = [
+        line.strip()
+        for line in playlist_content.splitlines()
+        if Path(line).suffix in SONG_FORMATS
+    ]
+    return only_tracks
+
+
+def get_playlist_for_vlc_android(path: Path) -> Tuple[str, str]:
+    """Return coverted playlist and its encoding."""
+    encoding = _detect_file_encoding(path)
+    playlist_content = path.read_text(encoding=encoding)
+
+    # Pattern for matching line into two groups:
+    # group 1 - all text before last backward or forward slash (including it)
+    # group 2 - filename (with extension)
+    regex_pattern = r"(.*[\\|\/])(.*)"
+
+    relative_playlist = re.sub(regex_pattern, r"\2", playlist_content)
+
+    # VLC for Android player does NOT understand square brackets [] and # in filenames
+    adapted_content = substitute_vlc_invalid_characters(relative_playlist)
+
+    return adapted_content, encoding
+
+
+def substitute_vlc_invalid_characters(content: str) -> str:
+    """Substitute [ and ] and # in filenames."""
+    adapted_content: str = ""
+    for line in content.splitlines():
+        # Replace characters only in filenames (not in comments)
+        if Path(line).suffix in SONG_FORMATS:
+            line = re.sub(r"[\[]", "%5B", line)
+            line = re.sub(r"[\]]", "%5D", line)
+            line = re.sub(r"[#]", "%23", line)
+        adapted_content += line + "\n"
+
+    return adapted_content

--- a/src/playlist_along/playlist.py
+++ b/src/playlist_along/playlist.py
@@ -91,7 +91,7 @@ def substitute_vlc_invalid_characters(content: str) -> str:
             line = re.sub(r"[\[]", "%5B", line)
             line = re.sub(r"[\]]", "%5D", line)
             line = re.sub(r"[#]", "%23", line)
-        adapted_content += line + "\n"
+        adapted_content += line.strip() + "\n"
 
     return adapted_content
 
@@ -107,10 +107,10 @@ def save_playlist_content(
     if encoding is None:
         encoding = "utf-8"
     try:
-        if Path(dest).is_dir() and origin is not None:
-            target_pls = Path(dest) / origin.name
+        if not dest.suffix and origin:
+            target_pls = dest / origin.name
         else:
-            target_pls = Path(dest)
+            target_pls = dest
         if origin:
             if target_pls.resolve() == origin.resolve():
                 suffix = target_pls.suffix

--- a/src/playlist_along/playlist.py
+++ b/src/playlist_along/playlist.py
@@ -101,13 +101,14 @@ def save_playlist_content(
     dest: Path,
     encoding: Optional[str] = None,
     origin: Optional[Path] = None,
+    explicit_dir: Optional[bool] = None,
 ) -> None:
     """Save playlist content to new destination."""
     target_pls: Path
     if encoding is None:
         encoding = "utf-8"
     try:
-        if not dest.suffix and origin:
+        if (not dest.suffix or explicit_dir) and origin:
             target_pls = dest / origin.name
         else:
             target_pls = dest

--- a/src/playlist_along/playlist.py
+++ b/src/playlist_along/playlist.py
@@ -43,7 +43,11 @@ def get_tracks_without_comment_lines(playlist_content: str) -> List[str]:
 def get_full_content_of_playlist(path: Path) -> Tuple[str, str]:
     """Return full content (text) of a playlist."""
     encoding = _detect_file_encoding(path)
-    playlist_content = path.read_text(encoding=encoding)
+    try:
+        playlist_content = path.read_text(encoding=encoding)
+    except (OSError) as error:
+        message = str(error)
+        raise ClickException(message)
     return playlist_content, encoding
 
 

--- a/src/playlist_along/playlist.py
+++ b/src/playlist_along/playlist.py
@@ -131,18 +131,22 @@ def copy_local_tracks_to_folder(tracklist: List[str], dest: str) -> None:
     file_destination: Path
     if not destination.is_dir():
         destination = destination.parent
-    for abs_path in tracklist:
-        if not Path(abs_path).exists():
-            missing_files.append(abs_path)
-        else:
-            name_only = Path(abs_path).name
-            file_destination = destination / name_only
-            if not file_destination.exists():
-                try:
-                    shutil.copy2(Path(abs_path), destination)
-                except (OSError) as error:
-                    message = str(error)
-                    raise ClickException(message)
+    with click.progressbar(
+        tracklist,
+        label="Copying from playlist:",
+    ) as bar:
+        for abs_path in bar:
+            if not Path(abs_path).exists():
+                missing_files.append(abs_path)
+            else:
+                name_only = Path(abs_path).name
+                file_destination = destination / name_only
+                if not file_destination.exists():
+                    try:
+                        shutil.copy2(Path(abs_path), destination)
+                    except (OSError) as error:
+                        message = str(error)
+                        raise ClickException(message)
     if missing_files:
         click.echo("Missing files from playlist were NOT copied:")
         click.echo("\n".join(missing_files))

--- a/src/playlist_along/playlist.py
+++ b/src/playlist_along/playlist.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import re
 from typing import List, Optional, Tuple
 
+from click import ClickException
+
 from ._utils import _detect_file_encoding
 
 
@@ -88,14 +90,19 @@ def save_playlist_content(
     target_pls: Path
     if encoding is None:
         encoding = "utf-8"
-    if Path(dest).is_dir() and origin is not None:
-        target_pls = Path(dest) / origin.name
-    else:
-        target_pls = Path(dest)
-    if origin:
-        if target_pls.resolve() == origin.resolve():
-            suffix = target_pls.suffix
-            new_name = str(target_pls.resolve().with_suffix("")) + "_vlc" + suffix
-            target_pls = Path(new_name)
+    try:
+        if Path(dest).is_dir() and origin is not None:
+            target_pls = Path(dest) / origin.name
+        else:
+            target_pls = Path(dest)
+        if origin:
+            if target_pls.resolve() == origin.resolve():
+                suffix = target_pls.suffix
+                new_name = str(target_pls.resolve().with_suffix("")) + "_vlc" + suffix
+                target_pls = Path(new_name)
 
-    target_pls.write_text(content, encoding)
+        target_pls.parent.mkdir(parents=True, exist_ok=True)
+        target_pls.write_text(content, encoding)
+    except (OSError) as error:
+        message = str(error)
+        raise ClickException(message)

--- a/src/playlist_along/playlist.py
+++ b/src/playlist_along/playlist.py
@@ -101,14 +101,14 @@ def save_playlist_content(
     dest: Path,
     encoding: Optional[str] = None,
     origin: Optional[Path] = None,
-    explicit_dir: Optional[bool] = None,
+    yes_dir: Optional[bool] = None,
 ) -> None:
     """Save playlist content to new destination."""
     target_pls: Path
     if encoding is None:
         encoding = "utf-8"
     try:
-        if (not dest.suffix or explicit_dir) and origin:
+        if (not dest.suffix or yes_dir) and origin:
             target_pls = dest / origin.name
         else:
             target_pls = dest

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -280,3 +280,33 @@ def test_cli_fails_on_copy_error(
         )
         assert result.exit_code == 1
         assert "Error" in result.output
+
+
+def test_cli_copies_files_into_folder_with_dot(runner: CliRunner) -> None:
+    """It copies files to destination folder with dot.
+
+    Test how is '--dir' option work.
+    """
+    with runner.isolated_filesystem():
+        with open("temp.m3u", "w") as f:
+            f.write(
+                """Track 01.mp3
+            Track 02.mp3
+            Track 03.flac
+            """
+            )
+        temp_folder = Path("temp.m3u").resolve().parent
+        # Create these files
+        Path(temp_folder / "Track 01.mp3").write_text("Here are music bytes")
+        Path(temp_folder / "Track 02.mp3").write_text("Here are music bytes")
+        Path(temp_folder / "Track 03.flac").write_text("Here are music bytes")
+        target_dest = temp_folder / "sub.m3u"
+        runner.invoke(
+            cli, ["--file", "temp.m3u", "convert", "--dest", str(target_dest), "--copy", "--dir"]
+        )
+        # Compare files in folders
+        origin_dir = [
+            child.name for child in temp_folder.iterdir() if not child.is_dir()
+        ]
+        converted_dir = [child.name for child in target_dest.iterdir()]
+        assert origin_dir == converted_dir

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -130,3 +130,118 @@ def test_cli_saves_playlist_with_different_name(runner: CliRunner) -> None:
         saved_file = temp_folder / "temp_vlc.m3u"
         result = runner.invoke(cli, ["--file", str(saved_file), "display"])
         assert result.output == "First %5Btrack!%5D.flac\n%23Second Track!.mp3\n"
+
+
+def test_cli_copies_files_from_playlist(runner: CliRunner) -> None:
+    """It copies files to destination of converted playlist."""
+    with runner.isolated_filesystem():
+        with open("temp.m3u", "w") as f:
+            f.write(
+                """Track 01.mp3
+            Track 02.mp3
+            Track 03.flac
+            """
+            )
+        temp_folder = Path("temp.m3u").resolve().parent
+        # Create these files
+        Path(temp_folder / "Track 01.mp3").write_text("Here are music bytes")
+        Path(temp_folder / "Track 02.mp3").write_text("Here are music bytes")
+        Path(temp_folder / "Track 03.flac").write_text("Here are music bytes")
+        target_dest = temp_folder / "sub"
+        runner.invoke(
+            cli, ["--file", "temp.m3u", "convert", "--dest", str(target_dest), "--copy"]
+        )
+        # Compare files in folders
+        origin_dir = [
+            child.name for child in temp_folder.iterdir() if not child.is_dir()
+        ]
+        converted_dir = [child.name for child in target_dest.iterdir()]
+        assert origin_dir == converted_dir
+
+
+def test_cli_prints_missing_files_after_coping(runner: CliRunner) -> None:
+    """It prints missing files in playlist after coping action."""
+    with runner.isolated_filesystem():
+        with open("temp.m3u", "w") as f:
+            f.write(
+                """Track 01.mp3
+            Track 02.mp3
+            Track 03.flac
+            """
+            )
+        temp_folder = Path("temp.m3u").resolve().parent
+        # Create these files
+        Path(temp_folder / "Track 01.mp3").write_text("Here are music bytes")
+        Path(temp_folder / "Track 03.flac").write_text("Here are music bytes")
+        target_dest = temp_folder / "sub"
+        result = runner.invoke(
+            cli, ["--file", "temp.m3u", "convert", "--dest", str(target_dest), "--copy"]
+        )
+        result_lines = str(result.output).splitlines()
+        line_1 = "Missing files from playlist were NOT copied:"
+        missing_name = "Track 02.mp3"
+        assert line_1 == result_lines[0]
+        assert missing_name == result_lines[1]
+
+
+def test_cli_copies_only_absent_files_by_default(runner: CliRunner) -> None:
+    """It copies only new files to destination folder.
+
+    Without overriding by default.
+    """
+    with runner.isolated_filesystem():
+        with open("temp.m3u", "w") as f:
+            f.write(
+                """Track 01.mp3
+            Track 02.mp3
+            Track 03.flac
+            """
+            )
+        temp_folder = Path("temp.m3u").resolve().parent
+        # Create these files
+        Path(temp_folder / "Track 01.mp3").write_text(
+            "Here are music bytes from origin"
+        )
+        Path(temp_folder / "Track 02.mp3").write_text("Here are music bytes")
+        Path(temp_folder / "Track 03.flac").write_text("Here are music bytes")
+        target_dest = temp_folder / "sub"
+        target_dest.mkdir()
+        Path(temp_folder / "sub" / "Track 01.mp3").write_text(
+            "Here are music bytes UPDATED"
+        )
+        runner.invoke(
+            cli, ["--file", "temp.m3u", "convert", "--dest", str(target_dest), "--copy"]
+        )
+        # Compare content of 'Track 01.mp3'
+        existing_in_sub = Path(temp_folder / "sub" / "Track 01.mp3").read_text()
+        expected = "Here are music bytes UPDATED"
+        assert expected == existing_in_sub
+
+
+def test_cli_dest_with_dot_is_file_by_default(runner: CliRunner) -> None:
+    """It processes path with dot as file of converted playlist."""
+    with runner.isolated_filesystem():
+        with open("temp.m3u", "w") as f:
+            f.write(
+                """Track 01.mp3
+            Track 02.mp3
+            Track 03.flac
+            """
+            )
+        temp_folder = Path("temp.m3u").resolve().parent
+        # Create these files
+        Path(temp_folder / "Track 01.mp3").write_text("Here are music bytes")
+        Path(temp_folder / "Track 02.mp3").write_text("Here are music bytes")
+        Path(temp_folder / "Track 03.flac").write_text("Here are music bytes")
+        target_dest = temp_folder / "sub" / "file.txt"
+        target_dest.parent.mkdir()
+        runner.invoke(
+            cli, ["--file", "temp.m3u", "convert", "--dest", str(target_dest), "--copy"]
+        )
+        # Check that copying is successful
+        converted_dir = [child.name for child in target_dest.parent.iterdir()]
+        assert len(converted_dir) == 4
+        # Check if destination file is created (not a folder)
+        target_playlist = Path(temp_folder / "sub" / "file.txt").read_text()
+        expected = "Track 01.mp3\nTrack 02.mp3\nTrack 03.flac\n"
+        assert expected == target_playlist

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -83,3 +83,50 @@ def test_cli_converts_tracklist_for_vlc(runner: CliRunner) -> None:
         )
         result = runner.invoke(cli, ["--file", str(target_file), "display"])
         assert result.output == "First %5Btrack!%5D.flac\n%23Second Track!.mp3\n"
+
+
+def test_cli_saves_playlist_with_same_name_for_folder(runner: CliRunner) -> None:
+    """It saves converted playlist with the same filename.
+
+    If destination option was passed as folder.
+    """
+    with runner.isolated_filesystem():
+        with open("temp.m3u", "w") as f:
+            f.write(
+                """D:\\tmp\\tmp_flack\\First [track!].flac
+            /home/user/Downloads/#Second Track!.mp3
+            """
+            )
+        temp_folder = Path("temp.m3u").resolve().parent
+
+        target_dest = temp_folder / "sub"
+        target_dest.mkdir()
+        runner.invoke(
+            cli, ["--file", "temp.m3u", "convert", "--dest", str(target_dest)]
+        )
+        saved_file = temp_folder / "sub" / "temp.m3u"
+        result = runner.invoke(cli, ["--file", str(saved_file), "display"])
+        assert result.output == "First %5Btrack!%5D.flac\n%23Second Track!.mp3\n"
+
+
+def test_cli_saves_playlist_with_different_name(runner: CliRunner) -> None:
+    """It saves converted playlist with auto added '_vlc'.
+
+    If destination file and origin playlist are the same.
+    """
+    with runner.isolated_filesystem():
+        with open("temp.m3u", "w") as f:
+            f.write(
+                """D:\\tmp\\tmp_flack\\First [track!].flac
+            /home/user/Downloads/#Second Track!.mp3
+            """
+            )
+        temp_folder = Path("temp.m3u").resolve().parent
+
+        target_file = temp_folder / "temp.m3u"
+        runner.invoke(
+            cli, ["--file", "temp.m3u", "convert", "--dest", str(target_file)]
+        )
+        saved_file = temp_folder / "temp_vlc.m3u"
+        result = runner.invoke(cli, ["--file", str(saved_file), "display"])
+        assert result.output == "First %5Btrack!%5D.flac\n%23Second Track!.mp3\n"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -36,13 +36,13 @@ def test_cli_prints_tracklist_itself(runner: CliRunner) -> None:
     with runner.isolated_filesystem():
         with open("tiny.m3u", "w") as f:
             f.write(
-                """First track!
-            Second Track!
+                """First track!.mp3
+            Second Track!.flac
             """
             )
 
         result = runner.invoke(cli, ["--file", "tiny.m3u"])
-        assert result.output == "First track!\nSecond Track!\n\n"
+        assert result.output == "First track!.mp3\nSecond Track!.flac\n"
 
 
 def test_cli_fails_unknown_command(runner: CliRunner) -> None:
@@ -56,10 +56,10 @@ def test_cli_prints_tracklist_with_display(runner: CliRunner) -> None:
     with runner.isolated_filesystem():
         with open("tiny.m3u", "w") as f:
             f.write(
-                """First track!
-            Second Track!
+                """First track!.flac
+            Second Track!.mp3
             """
             )
 
         result = runner.invoke(cli, ["--file", "tiny.m3u", "display"])
-        assert result.output == "First track!\nSecond Track!\n\n"
+        assert result.output == "First track!.flac\nSecond Track!.mp3\n"

--- a/tests/unit/test_playlist.py
+++ b/tests/unit/test_playlist.py
@@ -7,7 +7,7 @@ from playlist_along import playlist
 
 
 def test_playlist_passing_cyrillic_encoding(runner: CliRunner) -> None:
-    """It prints tracklist of playlist with 'display' command."""
+    """It prints tracklist with 'cp1251' encoding."""
     with runner.isolated_filesystem():
         with open("tiny.m3u", "w", encoding="cp1251") as f:
             f.write(

--- a/tests/unit/test_playlist.py
+++ b/tests/unit/test_playlist.py
@@ -26,12 +26,12 @@ def test_playlist_passing_cyrillic_encoding(runner: CliRunner) -> None:
 
 @pytest.fixture
 def mock_pathlib_write_text(mocker: MockFixture) -> Mock:
-    """Fixture for mocking wikipedia.random_page."""
+    """Fixture for mocking pathlib.Path.write_text."""
     pathlib_write_text: Mock = mocker.patch("pathlib.Path.write_text")
     return pathlib_write_text
 
 
-def test_saving_playlist_with__default_encoding(
+def test_saving_playlist_with_default_encoding(
     runner: CliRunner,
     mock_pathlib_write_text: Mock,
 ) -> None:

--- a/tests/unit/test_playlist.py
+++ b/tests/unit/test_playlist.py
@@ -55,7 +55,7 @@ def test_playlist_fails_on_writing_with_wrong_path_error() -> None:
     content = "ClickException if The filename, directory name, or volume label syntax is incorrect."
     dest = Path('="WrongPath.m3u"')
     with pytest.raises(ClickException) as exc_info:
-        _ = playlist.save_playlist_content(content, dest)
+        playlist.save_playlist_content(content, dest)
     assert exc_info.typename == "ClickException"
 
 
@@ -69,5 +69,5 @@ def test_playlist_fails_on_writing_with_permission_error(runner: CliRunner) -> N
 
         with pytest.raises(ClickException) as exc_info:
             # Try to write to a folder
-            _ = playlist.save_playlist_content(content, temp_folder)
+            playlist.save_playlist_content(content, temp_folder)
         assert exc_info.typename == "ClickException"

--- a/tests/unit/test_playlist.py
+++ b/tests/unit/test_playlist.py
@@ -1,7 +1,10 @@
 """Unit-tests for the playlist module."""
 from pathlib import Path
+from unittest.mock import Mock
 
 from click.testing import CliRunner
+import pytest
+from pytest_mock import MockFixture
 
 from playlist_along import playlist
 
@@ -18,3 +21,28 @@ def test_playlist_passing_cyrillic_encoding(runner: CliRunner) -> None:
         only_paths = playlist.get_only_track_paths_from_m3u(Path("tiny.m3u"), "cp1251")
         result = "\n".join(only_paths)
         assert result == "Кирилл - Track_01!.mp3\nМефодий - Track_02!.mp3"
+
+
+@pytest.fixture
+def mock_pathlib_write_text(mocker: MockFixture) -> Mock:
+    """Fixture for mocking wikipedia.random_page."""
+    return mocker.patch("pathlib.Path.write_text")
+
+
+def test_saving_playlist_with__default_encoding(
+    runner: CliRunner,
+    mock_pathlib_write_text: Mock,
+) -> None:
+    """It returns default encoding if it was not passed."""
+    with runner.isolated_filesystem():
+        with open("temp.m3u", "w") as f:
+            f.write(
+                """D:\\tmp\\tmp_flack\\First [track!].flac
+            /home/user/Downloads/#Second Track!.mp3
+            """
+            )
+        temp_folder = Path("temp.m3u").resolve().parent
+        target_file = temp_folder / "temp_converted.m3u"
+        temp_content = Path("temp.m3u").read_text()
+        playlist.save_playlist_content(temp_content, target_file)
+        mock_pathlib_write_text.assert_called_once_with(temp_content, "utf-8")

--- a/tests/unit/test_playlist.py
+++ b/tests/unit/test_playlist.py
@@ -104,3 +104,13 @@ def test_playlist_fails_on_reading_error(
         with pytest.raises(ClickException) as exc_info:
             playlist.get_full_content_of_playlist(temp_file)
         assert exc_info.typename == "ClickException"
+
+
+def test_playlist_substitutes_invalid_characters() -> None:
+    """It substitutes [ and ] and # in passed text."""
+    text = """Track - [01].mp3
+    #Track# - 02].flac
+    """
+    substituted = playlist.substitute_vlc_invalid_characters(text)
+    expected = "Track - %5B01%5D.mp3\n%23Track%23 - 02%5D.flac\n\n"
+    assert expected == substituted

--- a/tests/unit/test_playlist.py
+++ b/tests/unit/test_playlist.py
@@ -53,7 +53,7 @@ def test_saving_playlist_with_default_encoding(
 def test_playlist_fails_on_writing_with_wrong_path_error() -> None:
     """It raises ClickException if the playlist writing fails with wrong path."""
     content = "ClickException if The filename, directory name, or volume label syntax is incorrect."
-    dest = Path('="WrongPath.m3u"')
+    dest = Path("/::WrongPath.m3u")
     with pytest.raises(ClickException) as exc_info:
         playlist.save_playlist_content(content, dest)
     assert exc_info.typename == "ClickException"

--- a/tests/unit/test_playlist.py
+++ b/tests/unit/test_playlist.py
@@ -26,7 +26,8 @@ def test_playlist_passing_cyrillic_encoding(runner: CliRunner) -> None:
 @pytest.fixture
 def mock_pathlib_write_text(mocker: MockFixture) -> Mock:
     """Fixture for mocking wikipedia.random_page."""
-    return mocker.patch("pathlib.Path.write_text")
+    pathlib_write_text: Mock = mocker.patch("pathlib.Path.write_text")
+    return pathlib_write_text
 
 
 def test_saving_playlist_with__default_encoding(

--- a/tests/unit/test_playlist.py
+++ b/tests/unit/test_playlist.py
@@ -11,10 +11,10 @@ def test_playlist_passing_cyrillic_encoding(runner: CliRunner) -> None:
     with runner.isolated_filesystem():
         with open("tiny.m3u", "w", encoding="cp1251") as f:
             f.write(
-                """Кирилл - Track_01!
-            Мефодий - Track_02!
+                """Кирилл - Track_01!.mp3
+            Мефодий - Track_02!.mp3
             """
             )
         only_paths = playlist.get_only_track_paths_from_m3u(Path("tiny.m3u"), "cp1251")
         result = "\n".join(only_paths)
-        assert result == "Кирилл - Track_01!\nМефодий - Track_02!\n"
+        assert result == "Кирилл - Track_01!.mp3\nМефодий - Track_02!.mp3"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2,14 +2,13 @@
 from pathlib import Path
 
 import click
-from click.testing import CliRunner
 import pytest
 
 
 from playlist_along._utils import _detect_file_encoding
 
 
-def test_util_fails_on_encoding_detection_error(runner: CliRunner) -> None:
+def test_util_fails_on_encoding_detection_error() -> None:
     """It raises ClickException if the encoding detection fails."""
     with pytest.raises(click.ClickException) as exc_info:
         _ = _detect_file_encoding(Path('="WrongPath.m3u"'))

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,16 +1,33 @@
 """Unit-tests for the _utils module."""
 from pathlib import Path
+from unittest.mock import Mock
 
 import click
 import pytest
-
+from pytest_mock import MockFixture
 
 from playlist_along._utils import _detect_file_encoding
 
 
-def test_util_fails_on_encoding_detection_error() -> None:
+@pytest.fixture
+def mock__detect_file_encoding(mocker: MockFixture) -> Mock:
+    """Fixture for mocking _detect_file_encoding called from tests."""
+    detect_file_encoding: Mock = mocker.patch(
+        "playlist_along._utils._detect_file_encoding"
+    )
+    return detect_file_encoding
+
+
+def test_util_fails_on_encoding_detection_error(
+    mock__detect_file_encoding: Mock,
+) -> None:
     """It raises ClickException if the encoding detection fails."""
+    mock__detect_file_encoding.side_effect = OSError
     with pytest.raises(click.ClickException) as exc_info:
-        _ = _detect_file_encoding(Path('="WrongPath.m3u"'))
-        assert True is True
+        _ = _detect_file_encoding(Path("AnyPath.m3u"))
+    assert exc_info.typename == "ClickException"
+
+    mock__detect_file_encoding.side_effect = AttributeError
+    with pytest.raises(click.ClickException) as exc_info:
+        _ = _detect_file_encoding(Path("AnyPath.m3u"))
     assert exc_info.typename == "ClickException"


### PR DESCRIPTION
New command for converting AIMP _(Windows, desktop app)_ `.m3u` / `.m3u8` to playlists with relative paths for 'VLC for Android'

Syntax:

```bash
Usage: playlist-along -f <playlist> convert [OPTIONS]

  Converts playlist from one player to another.

Options:
  -d, --dest <string>  Directory or full path to playlist destination.
  --copy             Copy files from playlist.
  --dir                Tells script that destination is a dir, not a file 
                         (for directory name with '.' dot).
```

Refs:

https://github.com/hotenov/playlist-along/issues/6