### PR TITLE
Spilt commands up into sub-modules

### DIFF
--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -1,3 +1,6 @@
-.. click:: playlist_along.cli:cli
+Man Page
+==============
+
+.. click:: playlist_along.cli:cli_main
    :prog: playlist-along
    :nested: full

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ pytest-mock = "^3.6.0"
 furo = "^2021.4.11-beta.34"
 
 [tool.poetry.scripts]
-playlist-along = "playlist_along.cli:cli"
+playlist-along = "playlist_along.__main__:main"
 
 [tool.coverage.paths]
 source = ["src", "*/site-packages"]

--- a/src/playlist_along/__main__.py
+++ b/src/playlist_along/__main__.py
@@ -1,13 +1,12 @@
-"""Command-line interface."""
+"""Script entry point."""
 import sys
-from typing import Any
 
-from .cli import cli
+from .cli import cli_main as cli
 
 
-def main() -> Any:
-    """Return CLI click group."""
-    return cli()  # pragma: no cover
+def main() -> None:
+    """Calls 'cli_main' click group."""
+    cli()  # pragma: no cover
 
 
 if __name__ == "__main__":

--- a/src/playlist_along/commands/__init__.py
+++ b/src/playlist_along/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Package with CLI commands."""

--- a/src/playlist_along/commands/convert.py
+++ b/src/playlist_along/commands/convert.py
@@ -1,0 +1,49 @@
+"""Convert command."""
+from pathlib import Path
+from typing import List
+
+import click
+
+from .. import playlist
+from ..playlist import pass_playlist, Playlist
+
+
+@click.command(name="convert")
+@click.option(
+    "--dest",
+    "-d",
+    type=str,
+    help="Directory or full path to playlist destination.",
+    metavar="<string>",
+)
+@click.option(
+    "--copy",
+    is_flag=True,
+    help="Copy files from playlist.",
+)
+@click.option(
+    "--dir",
+    "yes_dir",
+    is_flag=True,
+    help="Tells script that destination is a dir, not a file (for directory name with '.' dot).",
+)
+@pass_playlist
+def convert_cmd(pls_obj: Playlist, dest: str, yes_dir: bool, copy: bool) -> None:
+    """Converts playlist from one player to another."""
+    file: Path = pls_obj.path
+    convert_from_aimp_to_vlc_android(file, dest, yes_dir)
+    if copy:
+        copy_files_from_playlist_to_destination_folder(file, dest)
+
+
+def convert_from_aimp_to_vlc_android(file: Path, dest: str, yes_dir: bool) -> None:
+    """Converts AIMP playlist to VLC for Android."""
+    converted_pls, encoding = playlist.get_playlist_for_vlc_android(file)
+    playlist.save_playlist_content(converted_pls, Path(dest), encoding, file, yes_dir)
+
+
+def copy_files_from_playlist_to_destination_folder(file: Path, dest: str) -> None:
+    """Copy tracks from playlist to folder with converted playlist."""
+    content, encoding = playlist.get_full_content_of_playlist(file)
+    only_tracks: List[str] = playlist.get_local_tracks_without_comment_lines(content)
+    playlist.copy_local_tracks_to_folder(only_tracks, dest)

--- a/src/playlist_along/commands/display.py
+++ b/src/playlist_along/commands/display.py
@@ -1,0 +1,22 @@
+"""Display command."""
+from pathlib import Path
+from typing import Optional
+
+import click
+
+from .. import playlist
+from ..playlist import pass_playlist, Playlist
+
+
+@click.command(name="display")
+@pass_playlist
+def display_cmd(pls_obj: Playlist) -> None:
+    """Displays tracks from playlist."""
+    file: Path = pls_obj.path
+    echo_tracks_with_click(file)
+
+
+def echo_tracks_with_click(file: Path, encoding: Optional[str] = None) -> None:
+    """Display only tracks from playlist file via click.echo()."""
+    only_paths = playlist.get_only_track_paths_from_m3u(file, encoding)
+    click.echo("\n".join(only_paths))

--- a/src/playlist_along/playlist.py
+++ b/src/playlist_along/playlist.py
@@ -21,6 +21,10 @@ class Playlist(object):
         self.path: Path = Path(path or ".")
 
 
+# Decorator for passing path to playlist file
+pass_playlist = click.make_pass_decorator(Playlist, ensure=True)
+
+
 def get_only_track_paths_from_m3u(
     path: Path, encoding: Optional[str] = None
 ) -> List[str]:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -6,7 +6,7 @@ from click.testing import CliRunner, Result
 import pytest
 from pytest_mock import MockFixture
 
-from playlist_along.cli import cli
+from playlist_along.cli import cli_main as cli
 
 
 def test_cli_prints_version(runner: CliRunner) -> None:


### PR DESCRIPTION
All commands are now in `commands` directory

Refs.:
https://github.com/hotenov/playlist-along/issues/34