### PR TITLE
Add displaying of full playlist content

### DIFF
--- a/src/playlist_along/commands/display.py
+++ b/src/playlist_along/commands/display.py
@@ -9,12 +9,23 @@ from ..playlist import pass_playlist, Playlist
 
 
 @click.command(name="display")
+@click.option(
+    "--full",
+    "-F",
+    "is_full",
+    is_flag=True,
+    help="Display a full content of playlist ('as-is').",
+)
 @pass_playlist
-def display_cmd(pls_obj: Playlist) -> None:
+def display_cmd(pls_obj: Playlist, is_full: bool) -> None:
     """Displays tracks from playlist."""
     file: Path = pls_obj.path
     if playlist.is_file_too_small(file):
         click.echo("Warning: Playlist is too small to display. Exit.")
+        click.get_current_context().exit()
+    elif is_full:
+        full_content, encoding = playlist.get_full_content_of_playlist(file)
+        click.echo(full_content)
         click.get_current_context().exit()
     else:
         echo_tracks_with_click(file)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -73,6 +73,28 @@ def test_cli_prints_tracklist_with_display(runner: CliRunner) -> None:
         assert result.output == "First track!.flac\nSecond Track!.mp3\n"
 
 
+def test_cli_displays_full_content_and_exits(runner: CliRunner) -> None:
+    """It displays a full content of playlist and then exits."""
+    with runner.isolated_filesystem():
+        with open("temp.m3u", "w") as f:
+            content = """\
+            #EXTM3U
+            Track 01.mp3
+
+            #EXTINF:2164,Title
+            Track 02.flac"""
+            f.write(dedent(content))
+
+        result = runner.invoke(
+            cli,
+            ["-f", "temp.m3u", "display", "--full"],
+        )
+
+        expected = "#EXTM3U\nTrack 01.mp3\n\n#EXTINF:2164,Title\nTrack 02.flac"
+        assert result.output == expected + "\n"
+        assert result.exit_code == 0
+
+
 def test_cli_converts_tracklist_for_vlc(runner: CliRunner) -> None:
     """It saves converted playlist with relative paths and with valid characters."""
     with runner.isolated_filesystem():


### PR DESCRIPTION
Refs https://github.com/hotenov/playlist-along/issues/30

Syntax:

```bash
playlist-along --file "example.m3u8" display --full
```

OR with short options:

```bash
playlist-along -f "example.m3u8" display -F
```