### PR TITLE
Upgrade typeguard from 2.12.0 to 2.12.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
           - { python-version: 3.6, os: ubuntu-latest, session: "tests" }
           - { python-version: 3.9, os: windows-latest, session: "tests" }
           - { python-version: 3.9, os: macos-latest, session: "tests" }
-          # - { python-version: 3.9, os: ubuntu-latest, session: "typeguard" }
+          - { python-version: 3.9, os: ubuntu-latest, session: "typeguard" }
           - { python-version: 3.9, os: ubuntu-latest, session: "xdoctest" }
           - { python-version: 3.8, os: ubuntu-latest, session: "docs-build" }
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,7 +26,7 @@ nox.options.sessions = (
     "safety",
     "mypy",
     "tests",
-    # "typeguard",  # wait for Click 8.0 release
+    "typeguard",
     "xdoctest",
     "docs-build",
 )

--- a/poetry.lock
+++ b/poetry.lock
@@ -890,7 +890,7 @@ python-versions = "*"
 
 [[package]]
 name = "typeguard"
-version = "2.12.0"
+version = "2.12.1"
 description = "Run-time type checker for Python"
 category = "dev"
 optional = false
@@ -956,7 +956,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "8409af6565621b3c32c0d83a9bd3214378e361c93245cbb188830c9c4e2da33f"
+content-hash = "f35bc31fc8d52821dd6ee7d5a17b86413384ac3e0aa0323a49c1ee24f438f76d"
 
 [metadata.files]
 alabaster = [
@@ -1504,8 +1504,8 @@ typed-ast = [
     {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
 ]
 typeguard = [
-    {file = "typeguard-2.12.0-py3-none-any.whl", hash = "sha256:7d1cf82b35e9ff3cd083133ebda54ad1d7a40296471397e6c6b229cf07fe5307"},
-    {file = "typeguard-2.12.0.tar.gz", hash = "sha256:fca77fd4ccba63465b421cdbbab5a1a8e3994e6d6f18b45da2bb475c09f147ef"},
+    {file = "typeguard-2.12.1-py3-none-any.whl", hash = "sha256:cc15ef2704c9909ef9c80e19c62fb8468c01f75aad12f651922acf4dbe822e02"},
+    {file = "typeguard-2.12.1.tar.gz", hash = "sha256:c2af8b9bdd7657f4bd27b45336e7930171aead796711bc4cfc99b4731bb9d051"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ pytest = "^6.2.4"
 coverage = {extras = ["toml"], version = "^5.4"}
 safety = "^1.10.3"
 mypy = "^0.812"
-typeguard = "^2.12.0"
+typeguard = "^2.12.1"
 xdoctest = {extras = ["colors"], version = "^0.15.4"}
 sphinx = "^3.5.4"
 sphinx-autobuild = "^2021.3.14"


### PR DESCRIPTION
This 'typeguard' version fixes errors:  `Group / Command object has no attribute __code__`

It lets us to enable 'typeguard' checking again.