### PR TITLE
ci(nox): Ignore 'ReDoS vulnerability in svnurl.py' of 'py' package (ID-51457) in 'safety' nox session

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -37,7 +37,13 @@ def safety(session: Session) -> None:
     """Scan dependencies for insecure packages."""
     requirements = session.poetry.export_requirements()
     session.install("safety")
-    session.run("safety", "check", "--full-report", f"--file={requirements}")
+    session.run(
+        "safety",
+        "check",
+        "--full-report",
+        f"--file={requirements}",
+        "--ignore=51457",
+    )
 
 
 @session(python=python_versions)


### PR DESCRIPTION
ReDoS vulnerability in svnurl.py of 'py' package.
pytest still depends on it and won't fix it until full drop 'py' dependency
Discussion: https://github.com/pytest-dev/py/issues/287